### PR TITLE
Must enforce state reset when adding/removing NNodes and edges

### DIFF
--- a/Graphs/AdjacencyList.cs
+++ b/Graphs/AdjacencyList.cs
@@ -39,36 +39,43 @@ namespace Graphs
             return 0;
         }
 
-        public override void AddNode(T n)
+        protected override void AddNodeByType(T n)
         {
-            this.Nodes.Add(n);
             this.edges.Add(this.Nodes.Count - 1, new HashSet<int>());
         }
 
-        public override void AddEdge(int from, int to, float weight = -1)
+		protected override void RemoveNodeByType(T n) {
+			foreach (var kvp in this.edges) {
+				kvp.Value.RemoveWhere(i => i.Equals(n));
+			}
+
+			this.edges.Remove(this.Nodes.IndexOf(n));
+		}
+
+		protected override void AddEdgeByIndex(int from, int to, float weight)
         {
             this.edges[from].Add(to);
             if (!this.IsDirected)
                 this.edges[to].Add(from);
         }
 
-        public override void AddEdge(T from, T to, float weight = -1)
+        protected override void AddEdgeByType(T from, T to, float weight)
         {
             var pair = this.GetNodePair(from, to);
-            this.AddEdge(pair.Item1, pair.Item2, weight);
+			this.AddEdgeByIndex(pair.Item1, pair.Item2, weight);
         }
 
-        public override void RemoveEdge(int from, int to)
+        protected override void RemoveEdgeByIndex(int from, int to)
         {
             this.edges[from].Remove(to);
             if (!this.IsDirected)
                 this.edges[to].Remove(from);
         }
 
-        public override void RemoveEdge(T from, T to)
+		protected override void RemoveEdgeByType(T from, T to)
         {
             var pair = this.GetNodePair(from, to);
-            this.RemoveEdge(pair.Item1, pair.Item2);
+			this.RemoveEdgeByIndex(pair.Item1, pair.Item2);
         }
 
         public override IEnumerable<int> Neighbors(int n)

--- a/Graphs/AdjacencyMatrix.cs
+++ b/Graphs/AdjacencyMatrix.cs
@@ -8,7 +8,7 @@ namespace Graphs
 {
     public class AdjacencyMatrix<T> : Graph<T>
     {
-        private float[,] adjacency;
+        private float[,] edges;
 
         private Action<int, int, float> addEdge;
         private Action<int, int> removeEdge;
@@ -16,12 +16,12 @@ namespace Graphs
         public AdjacencyMatrix(bool isDirected, bool isWeighted, int size)
         {
             this.Nodes = new List<T>(size);
-            this.adjacency = new float[size, size];
+            this.edges = new float[size, size];
             for (int i = 0; i < this.Nodes.Count; i++)
             {
                 for (int j = 0; j < this.Nodes.Count; j++)
                 {
-                    this.adjacency[i, j] = -1;
+                    this.edges[i, j] = -1;
                 }
             }
 
@@ -42,7 +42,7 @@ namespace Graphs
 
         public override bool EdgeExists(int from, int to)
         {
-            return this.adjacency[from, to] >= 0;
+            return this.edges[from, to] >= 0;
         }
 
         public override bool EdgeExists(T from, T to)
@@ -53,7 +53,7 @@ namespace Graphs
 
         public override float EdgeWeight(int from, int to)
         {
-            return this.adjacency[from, to];
+            return this.edges[from, to];
         }
 
         public override float EdgeWeight(T from, T to)
@@ -62,14 +62,33 @@ namespace Graphs
             return EdgeWeight(pair.Item1, pair.Item2);
         }
 
-        #region AddEdge
+		protected override void AddNodeByType(T n) {
+			var rows = this.edges.GetLength(0);
+			var cols = this.edges.GetLength(1);
 
-        public override void AddEdge(int from, int to, float weight)
+			var nEdges = new float[this.edges.GetLength(0) + 1, this.edges.GetLength(1) + 1];
+			for (int r = 0; r < rows; r++) {
+				for (int c = 0; c < cols; c++) {
+					if (r == rows - 1 || c == cols - 1)
+						nEdges[r, c] = 0;
+					else
+						nEdges[r, c] = this.edges[r, c];
+				}
+			}
+		}
+
+		protected override void RemoveNodeByType(T n) {
+			throw new NotImplementedException();
+		}
+
+		#region AddEdge
+
+		protected override void AddEdgeByIndex(int from, int to, float weight)
         {
             this.addEdge(from, to, weight);
         }
 
-        public override void AddEdge(T from, T to, float weight = -1)
+        protected override void AddEdgeByType(T from, T to, float weight = -1)
         {
             var pair = this.GetNodePair(from, to);
             this.addEdge(pair.Item1, pair.Item2, weight);
@@ -77,25 +96,25 @@ namespace Graphs
 
         private void addEdgeDirected(int from, int to, float weight)
         {
-            this.adjacency[from, to] = weight;
+            this.edges[from, to] = weight;
         }
 
         private void addEdgeUndirected(int from, int to, float weight)
         {
-            this.adjacency[from, to] = weight;
-            this.adjacency[to, from] = weight;
+            this.edges[from, to] = weight;
+            this.edges[to, from] = weight;
         }
 
         #endregion
 
         #region RemoveEdge
 
-        public override void RemoveEdge(int from, int to)
+        protected override void RemoveEdgeByIndex(int from, int to)
         {
             this.removeEdge(from, to);
         }
 
-        public override void RemoveEdge(T from, T to)
+		protected override void RemoveEdgeByType(T from, T to)
         {
             var pair = this.GetNodePair(from, to);
             this.removeEdge(pair.Item1, pair.Item2);
@@ -103,13 +122,13 @@ namespace Graphs
 
         private void removeEdgeDirected(int from, int to)
         {
-            this.adjacency[from, to] = -1;
+            this.edges[from, to] = -1;
         }
 
         private void removeEdgeUndirected(int from, int to)
         {
-            this.adjacency[from, to] = -1;
-            this.adjacency[to, from] = -1;
+            this.edges[from, to] = -1;
+            this.edges[to, from] = -1;
         }
 
         #endregion
@@ -120,7 +139,7 @@ namespace Graphs
         {
             for (int i = 0; i < this.Nodes.Count; i++)
             {
-                if (this.adjacency[n, i] >= 0)
+                if (this.edges[n, i] >= 0)
                     yield return i;
             }
         }

--- a/Graphs/Graph.cs
+++ b/Graphs/Graph.cs
@@ -7,171 +7,186 @@ using Utilities;
 
 namespace Graphs
 {
-    public abstract class Graph<T> : IGraph<T>
-    {
-        private Maybe<bool> isConnected = Maybe<bool>.None();
-        private Maybe<bool> isComplete = Maybe<bool>.None();
-        private Maybe<bool> isAcyclic = Maybe<bool>.None();
+	public abstract class Graph<T> : IGraph<T>
+	{
+		private Maybe<bool> isConnected = Maybe<bool>.None();
+		private Maybe<bool> isComplete = Maybe<bool>.None();
+		private Maybe<bool> isAcyclic = Maybe<bool>.None();
 
-        public IList<T> Nodes { get; protected set; }
-        public bool IsDirected { get; protected set; }
-        public bool IsWeighted { get; protected set; }
-        public bool IsConnected
-        {
-            get
-            {
-                return this.isConnected.Match(
-                    some: (v) => v,
-                    none: () =>
-                    {
-                        var start = this.RandomNode();
-                        var open = new Queue<int>();
-                        var closed = new HashSet<int>();
+		public IList<T> Nodes { get; protected set; }
+		public bool IsDirected { get; protected set; }
+		public bool IsWeighted { get; protected set; }
+		public bool IsConnected
+		{
+			get
+			{
+				return this.isConnected.Match(
+					some: (v) => v,
+					none: () =>
+					{
+						var start = this.RandomNode();
+						var open = new Queue<int>();
+						var closed = new HashSet<int>();
 
-                        open.Enqueue(start);
-                        closed.Add(start);
+						open.Enqueue(start);
+						closed.Add(start);
 
-                        while (open.Any())
-                        {
-                            var i = open.Dequeue();
-                            foreach (var n in this.Neighbors(i))
-                            {
-                                if (closed.Add(n))
-                                    open.Enqueue(n);
-                            }
-                        }
+						while (open.Any())
+						{
+							var i = open.Dequeue();
+							foreach (var n in this.Neighbors(i))
+							{
+								if (closed.Add(n))
+									open.Enqueue(n);
+							}
+						}
 
-                        this.isConnected = Maybe<bool>.Some(closed.Count == this.Nodes.Count);
-                        return this.isConnected.Value;
-                    });
-            }
-        }
-        public bool IsComplete
-        {
-            get
-            {
-                return this.isComplete.Match(
-                    some: (v) => v,
-                    none: () =>
-                    {
-                        for (int i = 0; i < this.Nodes.Count; i++)
-                        {
-                            // number of connections for each node must be greater or equal to the number of nodes in the graph (- 1 to account for self-connected nodes)
-                            var neighbourCount = this.Neighbors(i).Count();
-                            if (neighbourCount < this.Nodes.Count - 1)
-                            {
-                                this.isComplete = Maybe<bool>.Some(false);
-                                return this.isComplete.Value;
-                            }
-                        }
+						this.isConnected = Maybe<bool>.Some(closed.Count == this.Nodes.Count);
+						return this.isConnected.Value;
+					});
+			}
+		}
+		public bool IsComplete
+		{
+			get
+			{
+				return this.isComplete.Match(
+					some: (v) => v,
+					none: () =>
+					{
+						for (int i = 0; i < this.Nodes.Count; i++)
+						{
+							// number of connections for each node must be greater or equal to the number of nodes in the graph (- 1 to account for self-connected nodes)
+							var neighbourCount = this.Neighbors(i).Count();
+							if (neighbourCount < this.Nodes.Count - 1)
+							{
+								this.isComplete = Maybe<bool>.Some(false);
+								return this.isComplete.Value;
+							}
+						}
 
-                        this.isComplete = Maybe<bool>.Some(true);
-                        return this.isComplete.Value;
-                    });
-            }
-        }
-        public bool IsAcyclic
-        {
-            get
-            {
-                return this.isAcyclic.Match(
-                    some: (v) => v,
-                    none: () =>
-                    {
-                        if (!this.IsDirected)
-                        {
-                            this.isAcyclic = Maybe<bool>.Some(false);
-                            return this.isAcyclic.Value;
-                        }
+						this.isComplete = Maybe<bool>.Some(true);
+						return this.isComplete.Value;
+					});
+			}
+		}
+		public bool IsAcyclic
+		{
+			get
+			{
+				return this.isAcyclic.Match(
+					some: (v) => v,
+					none: () =>
+					{
+						if (!this.IsDirected)
+						{
+							this.isAcyclic = Maybe<bool>.Some(false);
+							return this.isAcyclic.Value;
+						}
 
-                        for (int i = 0; i < this.Nodes.Count; i++)
-                        {
-                            if (this.Search(i, i, Searching.SearchType.DFS))
-                            {
-                                this.isAcyclic = Maybe<bool>.Some(false);
-                                return this.isAcyclic.Value;
-                            }
-                        }
+						for (int i = 0; i < this.Nodes.Count; i++)
+						{
+							if (this.Search(i, i, Searching.SearchType.DFS))
+							{
+								this.isAcyclic = Maybe<bool>.Some(false);
+								return this.isAcyclic.Value;
+							}
+						}
 
-                        this.isAcyclic = Maybe<bool>.Some(true);
-                        return this.isAcyclic.Value;
-                    });
-            }
-        }
+						this.isAcyclic = Maybe<bool>.Some(true);
+						return this.isAcyclic.Value;
+					});
+			}
+		}
 
-        protected Tuple<int, int> GetNodePair(T from, T to)
-        {
-            int fromIndex = -1;
-            int toIndex = -1;
+		protected Tuple<int, int> GetNodePair(T from, T to)
+		{
+			int fromIndex = -1;
+			int toIndex = -1;
 
-            for (int i = 0; i < this.Nodes.Count; i++)
-            {
-                if (this.Nodes[i].Equals(from))
-                    fromIndex = i;
+			for (int i = 0; i < this.Nodes.Count; i++)
+			{
+				if (this.Nodes[i].Equals(from))
+					fromIndex = i;
 
-                if (this.Nodes[i].Equals(to))
-                    toIndex = i;
+				if (this.Nodes[i].Equals(to))
+					toIndex = i;
 
-                if (fromIndex >= 0 && toIndex >= 0)
-                    break;
-            }
+				if (fromIndex >= 0 && toIndex >= 0)
+					break;
+			}
 
-            return Tuple.Create(fromIndex, toIndex);
-        }
+			return Tuple.Create(fromIndex, toIndex);
+		}
 
-        public abstract bool EdgeExists(int from, int to);
-        public abstract bool EdgeExists(T from, T to);
+		public abstract bool EdgeExists(int from, int to);
+		public abstract bool EdgeExists(T from, T to);
 
-        public abstract float EdgeWeight(int from, int to);
-        public abstract float EdgeWeight(T from, T to);
+		public abstract float EdgeWeight(int from, int to);
+		public abstract float EdgeWeight(T from, T to);
 
-        public virtual void AddEdge(int from, int to, float weight = -1)
-        {
-            this.ResetProperties();
-        }
-        public virtual void AddEdge(T from, T to, float weight = -1)
-        {
-            this.ResetProperties();
-        }
+		public void AddEdge(int from, int to, float weight = -1)
+		{
+			this.ResetProperties();
+			this.AddEdgeByIndex(from, to, weight);
+		}
+		public void AddEdge(T from, T to, float weight = -1)
+		{
+			this.ResetProperties();
+			this.AddEdgeByType(from, to, weight);
+		}
 
-        public virtual void RemoveEdge(int from, int to)
-        {
-            this.ResetProperties();
-        }
-        public virtual void RemoveEdge(T from, T to)
-        {
-            this.ResetProperties();
-        }
+		protected abstract void AddEdgeByIndex(int from, int to, float weight);
+		protected abstract void AddEdgeByType(T from, T to, float weight);
 
-        public virtual void AddNode(T n)
-        {
-            this.ResetProperties();
-            this.Nodes.Add(n);
-        }
+		public void RemoveEdge(int from, int to)
+		{
+			this.ResetProperties();
+			this.RemoveEdgeByIndex(from, to);
+		}
+		public void RemoveEdge(T from, T to)
+		{
+			this.ResetProperties();
+			this.RemoveEdgeByType(from, to);
+		}
 
-        public virtual void RemoveNode(int n)
-        {
-            this.ResetProperties();
-            this.Nodes.RemoveAt(n);
-        }
+		protected abstract void RemoveEdgeByIndex(int from, int to);
+		protected abstract void RemoveEdgeByType(T from, T to);
 
-        public virtual void RemoveNode(T n)
-        {
-            this.ResetProperties();
-            this.Nodes.Remove(n);
-        }
+		public void AddNode(T n)
+		{
+			this.ResetProperties();
+			this.Nodes.Add(n);
+			this.AddNodeByType(n);
+		}
 
-        public abstract IEnumerable<int> Neighbors(int n);
-        public abstract IEnumerable<int> Neighbors(T n);
+		public void RemoveNode(int n)
+		{
+			this.ResetProperties();
+			this.RemoveNodeByType(this.Nodes[n]);
+			this.Nodes.RemoveAt(n);
+		}
 
-        /// <summary>
-        /// Resets flags so that graph properties are recalculated
-        /// </summary>
-        protected void ResetProperties()
-        {
-            this.isConnected = Maybe<bool>.None();
-            this.isComplete = Maybe<bool>.None();
-            this.isAcyclic = Maybe<bool>.None();
-        }
-    }
+		protected abstract void AddNodeByType(T n);
+		protected abstract void RemoveNodeByType(T n);
+
+		public virtual void RemoveNode(T n)
+		{
+			this.ResetProperties();
+			this.Nodes.Remove(n);
+		}
+
+		public abstract IEnumerable<int> Neighbors(int n);
+		public abstract IEnumerable<int> Neighbors(T n);
+
+		/// <summary>
+		/// Resets flags so that graph properties are recalculated
+		/// </summary>
+		protected void ResetProperties()
+		{
+			this.isConnected = Maybe<bool>.None();
+			this.isComplete = Maybe<bool>.None();
+			this.isAcyclic = Maybe<bool>.None();
+		}
+	}
 }


### PR DESCRIPTION
Modifying the graph should reset the computed state values. This must be enforced in children.
